### PR TITLE
add simple sorted event

### DIFF
--- a/d2l-dnd-sortable.html
+++ b/d2l-dnd-sortable.html
@@ -59,6 +59,12 @@ Reorderable drag-and-drop lists
 					type: String,
 					value: '',
 					observer: '_handleChanged'
+				},
+				/** Specify whether sorting (drag and drop) is enabled */
+				disabled: {
+					type: Boolean,
+					value: false,
+					observer: '_disabledChanged'
 				}
 			},
 
@@ -68,6 +74,7 @@ Reorderable drag-and-drop lists
 					dragClass: this.mirrorClass,
 					fallbackClass: this.touchMirrorClass,
 					handle: this.handle,
+					disabled: this.disabled,
 					onUpdate: this._onUpdate.bind(this)
 				};
 
@@ -94,6 +101,10 @@ Reorderable drag-and-drop lists
 
 			_handleChanged: function(value) {
 				this.sortable && this.sortable.option('handle', value);
+			},
+
+			_disabledChanged: function(value) {
+				this.sortable && this.sortable.option('disabled', value);
 			},
 
 			_onUpdate: function(evt) {

--- a/d2l-dnd-sortable.html
+++ b/d2l-dnd-sortable.html
@@ -27,21 +27,34 @@ Reorderable drag-and-drop lists
 		Polymer({
 			is: 'd2l-dnd-sortable',
 			properties: {
+
+				/**
+				 * Fired when the sortable list changes after a drag completes
+				 *
+				 * @event d2l-dnd-sorted
+				 * @param {number} oldIndex Original list index of dragged item
+				 * @param {number} newIndex New list index of dragged item
+				*/
+
+				/** CSS class name applied to the placeholder DOM node for the item being dragged */
 				placeholderClass: {
 					type: String,
 					value: 'placeholder',
 					observer: '_placeholderClassChanged'
 				},
+				/** CSS class name applied to the HTML 5 drag image of the item being dragged */
 				mirrorClass: {
 					type: String,
 					value: 'mirror',
 					observer: '_mirrorClassChanged'
 				},
+				/** CSS class name applied to the touch drag image of the item being dragged */
 				touchMirrorClass: {
 					type: String,
 					value: 'touch-mirror',
 					observer: '_touchMirrorClassChanged'
 				},
+				/** Specify a css selector for a handle element if you don't want to allow drag action on the entire element */
 				handle: {
 					type: String,
 					value: '',
@@ -54,7 +67,8 @@ Reorderable drag-and-drop lists
 					ghostClass: this.placeholderClass,
 					dragClass: this.mirrorClass,
 					fallbackClass: this.touchMirrorClass,
-					handle: this.handle
+					handle: this.handle,
+					onUpdate: this._onUpdate.bind(this)
 				};
 
 				this.sortable = window.Sortable.create(this, options);
@@ -82,6 +96,18 @@ Reorderable drag-and-drop lists
 				this.sortable && this.sortable.option('handle', value);
 			},
 
+			_onUpdate: function(evt) {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-dnd-sorted', {
+						bubbles: true,
+						composed: true,
+						detail: {
+							oldIndex: evt.oldIndex,
+							newIndex: evt.newIndex
+						}
+					}
+				));
+			}
 		});
 	</script>
 </dom-module>

--- a/demo/index.html
+++ b/demo/index.html
@@ -53,16 +53,21 @@
 			</demo-snippet>
 		</div>
 		<div class="vertical-section-container centered">
-			<h3>Simple list with drag handle</h3>
+			<h3>Simple list with drag handle and enable/disable dragging</h3>
 			<demo-snippet>
 				<template>
 					<ul style="position:relative">
-						<d2l-dnd-sortable handle=".drag-handle">
-							<li><span class="drag-handle">↕</span>One, Two, Three, Four, Five, Once I caught a fish alive</li>
-							<li><span class="drag-handle">↕</span>Six, Seven, Eight, Nine, Ten, Then I let him go again</li>
-							<li><span class="drag-handle">↕</span>Why did you let him go</li>
-							<li><span class="drag-handle">↕</span>Because he bit my finger so</li>
-						</d2l-dnd-sortable>
+						<dom-bind>
+							<template is="dom-bind">
+								<d2l-dnd-sortable handle=".drag-handle" id="sortable1">
+									<li><span class="drag-handle">↕</span>One, Two, Three, Four, Five, Once I caught a fish alive</li>
+									<li><span class="drag-handle">↕</span>Six, Seven, Eight, Nine, Ten, Then I let him go again</li>
+									<li><span class="drag-handle">↕</span>Why did you let him go</li>
+									<li><span class="drag-handle">↕</span>Because he bit my finger so</li>
+								</d2l-dnd-sortable>
+								<button onclick="sortable1.disabled = !sortable1.disabled">Toggle Drag Drop Enabled</button>
+							</template>
+						</dom-bind>
 					</ul>
 				</template>
 			</demo-snippet>

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,10 +38,11 @@
 	<body unresolved class="d2l-typography">
 		<div class="vertical-section-container centered">
 			<h3>Simple list</h3>
+			<h4>(see Dev Tools Inspector Console for events)</h4>
 			<demo-snippet>
 				<template>
 					<ul style="position:relative">
-						<d2l-dnd-sortable>
+						<d2l-dnd-sortable id="simple-sortable">
 							<li>One, Two, Three, Four, Five, Once I caught a fish alive</li>
 							<li>Six, Seven, Eight, Nine, Ten, Then I let him go again</li>
 							<li>Why did you let him go</li>
@@ -113,6 +114,16 @@
 							value: 'Six, Seven, Eight, Nine, Ten, Then I let him go again'
 						}
 					];
+				});
+
+				var nestedSortable = document.querySelector('#simple-sortable');
+				nestedSortable.addEventListener('d2l-dnd-sorted', function(e) {
+					// eslint-disable-next-line no-console
+					console.log({
+						'event': e.type,
+						'detail.oldIndex': e.detail.oldIndex,
+						'detail.newIndex': e.detail.newIndex
+					});
 				});
 			});
 		</script>


### PR DESCRIPTION
This is the new wrapper around SortableJS.

Inspired by polymer-sortablejs, but I went with a very minimalist approach of only including what we needed. It's mostly to provide an abstraction layer around SortableJS in case we want to replace later with a different DnD lib.

The polymer-sortablejs binding hooked directly into the polymer dom-repeat and spliced the changes into the dom-repeat item structure. But I have not decided if I like that approach yet, or whether its necessary, so just sticking with simple list operations for now with an event to say what the old and new indexes were.

If it becomes necessary to manipulate the dom-repeat items directly, we can add it later.

polymer-sortablejs also did some hacking of the draggable and sort attributes that I didn't fully understand, so I've left that out for now too.

I'm going to work on integrating the dnd-sorted event with the rubric editor next.