### PR TITLE
US99693 - Use d2l-input-textarea component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,12 +20,12 @@
     "Sortable": "Brightspace/Sortable#1.6.0-bs1"
   },
   "devDependencies": {
+    "d2l-inputs": "^1.0.1",
     "d2l-typography": "BrightspaceUI/typography#^6.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^2.0.0",
-    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
-    "d2l-textarea": "BrightspaceUI/textarea#^0.6.1"
+    "web-component-tester": "Polymer/web-component-tester#^6.0.0"
   },
   "variants": {
     "1.x": {

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,7 @@
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 		<link rel="import" href="../../d2l-typography/d2l-typography.html">
-		<link rel="import" href="../../d2l-textarea/d2l-textarea.html">
+		<link rel="import" href="../../d2l-inputs/d2l-input-textarea.html">
 		<link rel="import" href="../d2l-dnd-sortable.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles"></style>
@@ -98,7 +98,7 @@
 						<dom-bind class="dom-repeat-demo-2">
 							<template is="dom-bind" class="dom-repeat-demo-1">
 								<template is="dom-repeat" items=[[phrases]]>
-									<div><d2l-textarea value="[[item.value]]"></d2l-textarea></div>
+									<div><d2l-input-textarea value="[[item.value]]"></d2l-input-textarea></div>
 								</template>
 							</template>
 						</dom-bind>


### PR DESCRIPTION
Remove `d2l-textarea` and use `d2l-inputs`'s `d2l-input-textarea` component instead.

I want to get deprecated `d2l-textarea` out of BSI, so I'm replacing its usages with the new `d2l-input-textarea` component.  Since this is a dev dependency I don't really need to change it, but I'm going to be making updates to rubrics (where this is used) anyways.