### PR TITLE
Use older version of Sortable

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   "main": "d2l-dnd-sortable.js",
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "sortablejs": "^1.8.0-rc1"
+    "sortablejs": "SortableJS/Sortable#8794188794"
   }
 }


### PR DESCRIPTION
This version works in Polymer 3 in Edge and IE, whereas the v1.8.1 version does not