### PR TITLE
Use Our Fork to Fix UMB Time Bomb

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "sauce-connect-launcher": "^1.2.4",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "3.0.1",
+  "version": "3.0.2",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",
@@ -41,6 +41,6 @@
   "main": "d2l-dnd-sortable.js",
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "sortablejs": "SortableJS/Sortable#8794188794"
+    "sortablejs": "Brightspace/Sortable#1.6.0-bs1"
   }
 }


### PR DESCRIPTION
Use D2L's fork that de-umd-ifies sortablejs to fix the latest occurrence of the UMD ticking time bomb explosion.  It looks like Polymer 1/2 hybrid was using this version, but it was lost in the conversion to Polymer 3.

This hasn't been a problem, but `d2l-rubric-criteria-editor` (which uses this) was just pulled into the shared bundle.