### PR TITLE
check if sortable.el is null before calling destroy

### DIFF
--- a/d2l-dnd-sortable.js
+++ b/d2l-dnd-sortable.js
@@ -91,7 +91,7 @@ Polymer({
 	},
 
 	detached: function() {
-		if (this.sortable) {
+		if (this.sortable && this.sortable.el) {
 			this.sortable.destroy();
 		}
 	},


### PR DESCRIPTION
[DE39798](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F404638387292&fdp=true)

Issue:
- Edge calls detached() twice which calls destroy() when attempting to attach a new rubric or cancel attaching it 
- The first time destroy() is called from [Sortable.js](https://search.d2l.dev/xref/GitHub/Brightspace/Sortable/Sortable.js?r=a8d96e45), sortable.el will be set to null
- Since it is set to null, an error will be thrown the second time destroy() is called

Fix:
- Check if sortable.el is null before trying to call destroy()

Testing:
- Tested on Edge and on Chrome that attaching a new rubric still works
